### PR TITLE
fix youtube ext: items not loading on channel urls.

### DIFF
--- a/shoutem.youtube/app/redux.js
+++ b/shoutem.youtube/app/redux.js
@@ -196,6 +196,7 @@ function buildFeedParams(feedUrl, apiKey) {
         channelId: extractChannelId(feedUrl),
         key: apiKey,
       },
+      feedUrl
     };
   } else if (/playlist/i.test(feedUrl)) {
     return {
@@ -204,6 +205,7 @@ function buildFeedParams(feedUrl, apiKey) {
         playlistId: extractPlaylistId(feedUrl),
         key: apiKey,
       },
+      feedUrl
     };
   }
   return {};


### PR DESCRIPTION
for channel URLs (e.g. https://www.youtube.com/channel/UCrJs_gMaJZDqN6Wz76FQ35A) the view is not loading, because the payload data it gets from redux is not being saved to the extension's state. video items are saved on extension state via its feedUrl, I noticed that for user URL, the feedUrl param is included but not on channel and other types, which I believe causing not to be able to store it because there's no url to reference.

I have added "feedUrl" on return values of buildFeedParams() and the items were now loading on my end. I have only tested this on 1.3.3 platform because its the current platform of the app I am currently working on. but lemme know if this fix is not compatible to the current one.