### PR TITLE
Added showPushNotification Action + Middleware

### DIFF
--- a/shoutem.push-notifications/app/app.js
+++ b/shoutem.push-notifications/app/app.js
@@ -1,11 +1,4 @@
-import _ from 'lodash';
-
-import {
-  Alert,
-  AppState,
-} from 'react-native';
-
-import { I18n } from 'shoutem.i18n';
+import { AppState } from 'react-native';
 
 import { ext } from './const';
 
@@ -13,6 +6,7 @@ import {
   selectPushNotificationGroups,
   userNotified,
   requestPushPermission,
+  showPushNotification,
 } from './redux';
 
 const DEFAULT_PUSH_NOTIFICATION_GROUP = 'broadcast';
@@ -38,30 +32,10 @@ const appDidMount = (app) => {
     return state[ext()].lastNotification;
   }
 
-  function onNotificationAction(notificationContent) {
-    const action = _.get(notificationContent, 'action');
-
-    if (!!action) {
-      store.dispatch(action);
-    }
-  }
-
   function displayPushNotificationMessage(notification) {
     const notificationContent = notification.content;
-    store.dispatch(userNotified());
-
-    if(notificationContent.openedFromTray) {
-      return onNotificationAction(notificationContent);
-    }
-
-    Alert.alert(
-      I18n.t(ext('messageReceivedAlert')),
-      notificationContent.body,
-      [
-        { text: I18n.t(ext('messageReceivedAlertView')), onPress: onNotificationAction.bind(null, notificationContent) },
-        { text: I18n.t(ext('messageReceivedAlertDismiss')), onPress: () => {} },
-      ]
-    );
+    store.dispatch(userNotified());    
+    store.dispatch(showPushNotification(notificationContent));
   }
 
   store.subscribe(() => {

--- a/shoutem.push-notifications/app/index.js
+++ b/shoutem.push-notifications/app/index.js
@@ -6,6 +6,7 @@ import {
   USER_NOTIFIED,
   REQUEST_PUSH_PERMISSION,
   DEVICE_TOKEN_RECEIVED,
+  SHOW_PUSH_NOTIFICATION,
 } from './redux';
 
 import { appDidMount, appWillMount, appWillUnmount } from './app';
@@ -13,6 +14,8 @@ import { appDidMount, appWillMount, appWillUnmount } from './app';
 import Permissions from './permissions';
 
 import enTranslations from './translations/en.json';
+
+import middleware from './middleware';
 
 export const DEFAULT_PUSH_NOTIFICATION_GROUP = 'broadcast';
 
@@ -36,4 +39,6 @@ export {
   appWillMount,
   appWillUnmount,
   Permissions,
+  middleware,
+  SHOW_PUSH_NOTIFICATION,
 };

--- a/shoutem.push-notifications/app/index.js
+++ b/shoutem.push-notifications/app/index.js
@@ -29,7 +29,7 @@ export const shoutem = {
 
 export const middleware = [
   showNotification,
-]
+];
 
 export {
   reducer,

--- a/shoutem.push-notifications/app/index.js
+++ b/shoutem.push-notifications/app/index.js
@@ -15,7 +15,7 @@ import Permissions from './permissions';
 
 import enTranslations from './translations/en.json';
 
-import middleware from './middleware';
+import { showNotification } from './middleware';
 
 export const DEFAULT_PUSH_NOTIFICATION_GROUP = 'broadcast';
 
@@ -26,6 +26,10 @@ export const shoutem = {
     },
   },
 };
+
+export const middleware = [
+  showNotification,
+]
 
 export {
   reducer,
@@ -39,6 +43,5 @@ export {
   appWillMount,
   appWillUnmount,
   Permissions,
-  middleware,
   SHOW_PUSH_NOTIFICATION,
 };

--- a/shoutem.push-notifications/app/middleware.js
+++ b/shoutem.push-notifications/app/middleware.js
@@ -1,11 +1,9 @@
 import { Alert } from 'react-native';
-
 import FCM from 'react-native-fcm';
-
 import _ from 'lodash';
 
 import { I18n } from 'shoutem.i18n';
-
+ 
 import { SHOW_PUSH_NOTIFICATION } from './redux';
 
 function onNotificationAction(notificationContent, store) {

--- a/shoutem.push-notifications/app/middleware.js
+++ b/shoutem.push-notifications/app/middleware.js
@@ -1,41 +1,39 @@
-import _ from 'lodash';
-
 import { Alert } from 'react-native';
-
-import { SHOW_PUSH_NOTIFICATION } from './redux';
 
 import FCM from 'react-native-fcm';
 
+import _ from 'lodash';
+
 import { I18n } from 'shoutem.i18n';
 
-// eslint-disable-next-line no-unused-vars
-const showNotification = store => next => action => {  
-  if (action.type === SHOW_PUSH_NOTIFICATION) {
-    notificationContent = action.payload.notification;
-    
-    function onNotificationAction(notificationContent) {
-      const action = _.get(notificationContent, 'action');
-    
-      if (!!action) {
-        store.dispatch(action);
-      }
-    }
-    
-    if (notificationContent.openedFromTray) {
-      return onNotificationAction(notificationContent);
-    }
-    
-    Alert.alert(
-      I18n.t(ext('messageReceivedAlert')),
-      notificationContent.body,
-      [
-        { text: I18n.t(ext('messageReceivedAlertView')), onPress: onNotificationAction.bind(null, notificationContent) },
-        { text: I18n.t(ext('messageReceivedAlertDismiss')), onPress: () => {} },
-      ]
-    );
+import { SHOW_PUSH_NOTIFICATION } from './redux';
+
+function onNotificationAction(notificationContent, store) {
+  const action = _.get(notificationContent, 'action');
+
+  if (!!action) {
+    store.dispatch(action);
   }
+}
 
-  return next(action);
+// eslint-disable-next-line no-unused-vars
+export const showNotification = store => next => action => {
+  if (action.type !== SHOW_PUSH_NOTIFICATION) {
+    return next(action);
+  }
+  
+  const notificationContent = _.get(action, 'payload.notification');
+  
+  if (notificationContent.openedFromTray) {
+    return onNotificationAction(notificationContent, store);
+  }
+  
+  Alert.alert(
+    I18n.t(ext('messageReceivedAlert')),
+    notificationContent.body,
+    [
+      { text: I18n.t(ext('messageReceivedAlertView')), onPress: onNotificationAction.bind(null, notificationContent, store) },
+      { text: I18n.t(ext('messageReceivedAlertDismiss')), onPress: () => {} },
+    ]
+  );
 };
-
-export default [showNotification];

--- a/shoutem.push-notifications/app/middleware.js
+++ b/shoutem.push-notifications/app/middleware.js
@@ -1,0 +1,41 @@
+import _ from 'lodash';
+
+import { Alert } from 'react-native';
+
+import { SHOW_PUSH_NOTIFICATION } from './redux';
+
+import FCM from 'react-native-fcm';
+
+import { I18n } from 'shoutem.i18n';
+
+// eslint-disable-next-line no-unused-vars
+const showNotification = store => next => action => {  
+  if (action.type === SHOW_PUSH_NOTIFICATION) {
+    notificationContent = action.payload.notification;
+    
+    function onNotificationAction(notificationContent) {
+      const action = _.get(notificationContent, 'action');
+    
+      if (!!action) {
+        store.dispatch(action);
+      }
+    }
+    
+    if (notificationContent.openedFromTray) {
+      return onNotificationAction(notificationContent);
+    }
+    
+    Alert.alert(
+      I18n.t(ext('messageReceivedAlert')),
+      notificationContent.body,
+      [
+        { text: I18n.t(ext('messageReceivedAlertView')), onPress: onNotificationAction.bind(null, notificationContent) },
+        { text: I18n.t(ext('messageReceivedAlertDismiss')), onPress: () => {} },
+      ]
+    );
+  }
+
+  return next(action);
+};
+
+export default [showNotification];

--- a/shoutem.push-notifications/app/redux/actionCreators.js
+++ b/shoutem.push-notifications/app/redux/actionCreators.js
@@ -2,6 +2,7 @@ import {
   USER_NOTIFIED,
   REQUEST_PUSH_PERMISSION,
   SELECT_PUSH_NOTIFICATION_GROUPS,
+  SHOW_PUSH_NOTIFICATION,
 } from './actionTypes';
 
 /**
@@ -39,3 +40,17 @@ export function selectPushNotificationGroups({ added, removed }) {
   };
 }
 
+/**
+ * @see SHOW_PUSH_NOTIFICATION
+ * Used for displaying a push notification when the app is open
+ * @param notification - the notification to display
+ * @returns {{type: String, payload: {notification: Object}}}
+ */
+export function showPushNotification(notification) {
+  return {
+    type: SHOW_PUSH_NOTIFICATION,
+    payload: {
+      notification,
+    }
+  };
+}

--- a/shoutem.push-notifications/app/redux/actionTypes.js
+++ b/shoutem.push-notifications/app/redux/actionTypes.js
@@ -36,3 +36,11 @@ export const REQUEST_PUSH_PERMISSION = 'shoutem.push-notifications.REQUEST_PUSH_
  @property token String
  */
 export const DEVICE_TOKEN_RECEIVED = 'shoutem.push-notifications.DEVICE_TOKEN_RECEIVED';
+
+/**
+ @typedef SHOW_PUSH_NOTIFICATION
+ @type {object}
+ @property type String
+ @property token String
+ */
+export const SHOW_PUSH_NOTIFICATION = 'shoutem.push-notifications.SHOW_PUSH_NOTIFICATION';

--- a/shoutem.push-notifications/app/redux/index.js
+++ b/shoutem.push-notifications/app/redux/index.js
@@ -4,6 +4,7 @@ export {
   USER_NOTIFIED,
   REQUEST_PUSH_PERMISSION,
   DEVICE_TOKEN_RECEIVED,
+  SHOW_PUSH_NOTIFICATION,
 } from './actionTypes';
 
 export {


### PR DESCRIPTION
Dispatch a showPushNotification Action when displaying a push notification when the app is open and handle the logic in a middleware. This design allows for customisation of the show push notification dialog for shoutem developers.