### PR TITLE
User sees screens visible to "All signed in users", but not screens assigned to their group

### DIFF
--- a/shoutem.auth/app/package.json
+++ b/shoutem.auth/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shoutem.auth",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Authentication extension that uses the Shoutem authentication backend.",
   "dependencies": {
     "buffer": "^4.5.1",

--- a/shoutem.auth/extension.json
+++ b/shoutem.auth/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "auth",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "platform": "1.6.*",
   "title": "Users",
   "icon": "server/assets/add-authentication-image.png",

--- a/shoutem.auth/server/package.json
+++ b/shoutem.auth/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shoutem.auth",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Shoutem user authentication",
   "author": "Shoutem",
   "scripts": {


### PR DESCRIPTION
To my untrained eyes it seems that the only way to leave the login screen is using the onLoginSuccess() callback, which makes this a rather simple fix as we just need to wait a bit longer for the user object to be populated and valid, because the issue happens when hideShortcuts() gets called with user's groups empty, so every shortcut gets hidden. 

Another solution would be to add a global state subscriber to user object which could call hideShortcuts() everytime user object changes, but I have not found a good place to place such a contraption. 