### PR TITLE
Fixes error where apps opened through deep links can crash

### DIFF
--- a/shoutem.preview/app/app.js
+++ b/shoutem.preview/app/app.js
@@ -2,15 +2,13 @@ import { Linking } from 'react-native';
 
 import {
   RESTART_APP,
-  openInitialScreen,
-  actions,
   isProduction,
   getAppId,
 } from 'shoutem.application';
 
 function getAppIdFromUrl(url) {
   const matches = url.match(/preview:\/\/open-app\/([0-9]*)/);
-  return matches.length ? matches[1] : undefined;
+  return matches.length >= 2 ? matches[1] : undefined;
 }
 
 function listenForDeepLinks(dispatch) {


### PR DESCRIPTION
A simple out of bounds array access happens when the app is opened through a deep link.

This PR fixes the bug by simply checking the array length before accessing it.

Also, some unused imports were removed.