### PR TITLE
fix webview loading screen to cover the whole screen

### DIFF
--- a/shoutem.web-view/app/screens/WebViewScreen.js
+++ b/shoutem.web-view/app/screens/WebViewScreen.js
@@ -112,9 +112,18 @@ export class WebViewScreen extends PureComponent {
 
   renderLoadingSpinner() {
     return (
-      <View styleName="xl-gutter-top">
+      <Screen
+        style={{
+          position: 'absolute',
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
+          width: '100%',
+        }}
+      >
         <Spinner styleName="lg-gutter-top" />
-      </View>
+      </Screen>
     );
   }
 


### PR DESCRIPTION
With shoutem platform 2.1.0-rc3 and the new react-native-webview 5.12.1, the loading screen shows a white view, see:
![Simulator Screen Shot - iPhone X - 2019-08-09 at 16 13 29](https://user-images.githubusercontent.com/3884582/62785414-e29df280-bac0-11e9-9a87-06c5d41da605.png)


For the issue see: https://github.com/react-native-community/react-native-webview/issues/684

I applied the default styling for the loading screen taken from here: https://github.com/react-native-community/react-native-webview/blob/master/src/WebView.styles.ts#L17
