### PR TITLE
Set initial route based on startingScreen setting

### DIFF
--- a/shoutem.navigation/app/navigators/TabBarNavigator.js
+++ b/shoutem.navigation/app/navigators/TabBarNavigator.js
@@ -59,6 +59,15 @@ function customStackScreenOptions(navigationProps) {
 }
 
 function Navigator({ parentShortcut, hiddenShortcuts, screens, style }) {
+  const initialShortcutId = _.get(
+    parentShortcut,
+    'screens[0].settings.startingScreen',
+  );
+
+  const initialShortcut = _.find(parentShortcut.children, {
+    id: initialShortcutId,
+  });
+
   const TabComponents = createChildNavigators(
     parentShortcut,
     TabBarStack,
@@ -81,6 +90,7 @@ function Navigator({ parentShortcut, hiddenShortcuts, screens, style }) {
 
   return (
     <TabBarStack.Navigator
+      initialRouteName={initialShortcut?.navigationCanonicalName}
       tabBarOptions={{
         activeTintColor: style.activeTintColor,
         inactiveTintColor: style.inactiveTintColor,


### PR DESCRIPTION
In Shoutem Builder, it is possible to select _Starting screen_ for the app. However, this config is not used in `TabBarNavigator`.

This PR extends `TabBarNavigator` by adding support for `startingScreen` setting. It is basically the same implementation taken from `DrawerNavigator` [here](https://github.com/shoutem/extensions/blob/master/shoutem.navigation/app/navigators/DrawerNavigator.js#L109).